### PR TITLE
Add PDF preview rendering with draggable stamp

### DIFF
--- a/docgen-form/app/zh-CN/confirmation/page.jsx
+++ b/docgen-form/app/zh-CN/confirmation/page.jsx
@@ -1,5 +1,17 @@
 'use client';
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
+
+let pdfWorkerConfigured = false;
+
+async function loadPdfjs() {
+  const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf');
+  if (typeof window !== 'undefined' && !pdfWorkerConfigured && pdfjsLib?.GlobalWorkerOptions) {
+    const version = pdfjsLib?.version || '3.11.174';
+    pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${version}/pdf.worker.min.js`;
+    pdfWorkerConfigured = true;
+  }
+  return pdfjsLib;
+}
 
 export default function ConfirmationPage() {
   const [brand, setBrand] = useState('vanka'); // vanka / duoji
@@ -18,10 +30,22 @@ export default function ConfirmationPage() {
     others: '',
     remark: ''
   });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [pdfPages, setPdfPages] = useState([]);
+  const pdfContainerRef = useRef(null);
+  const stampRef = useRef(null);
+  const dragOffsetRef = useRef({x: 0, y: 0});
+  const [stampPosition, setStampPosition] = useState({x: 32, y: 32});
+  const [draggingStamp, setDraggingStamp] = useState(false);
   const onChange = (k,v) => setForm(prev=>({...prev,[k]:v}));
 
   async function handleGenerate(e){
     e.preventDefault();
+
+    setLoading(true);
+    setError('');
+    setPdfPages([]);
 
     const templateKey = brand === 'vanka' ? 'confirmation_vanka' : 'confirmation_duoji';
     const data = {
@@ -46,28 +70,112 @@ export default function ConfirmationPage() {
       docTypeLabel: brand === 'vanka' ? '确认函-万咖' : '确认函-多吉'
     };
 
-    const res = await fetch('/api/generate', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ templateKey, data, meta })
-    });
+    try {
+      const res = await fetch('/api/preview', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ templateKey, data, meta })
+      });
 
-    if (!res.ok) {
-      const text = await res.text().catch(()=> '');
-      alert('生成失败：' + text);
-      return;
+      if (!res.ok) {
+        const text = await res.text().catch(()=> '');
+        throw new Error(text || '生成失败');
+      }
+
+      const blob = await res.blob();
+      await renderPdfBlob(blob);
+      setStampPosition({x: 32, y: 32});
+    } catch (err) {
+      console.error(err);
+      const message = err?.message || '生成失败';
+      setError(message);
+      alert('生成失败：' + message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function renderPdfBlob(blob) {
+    const arrayBuffer = await blob.arrayBuffer();
+    const pdfjsLib = await loadPdfjs();
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    const pages = [];
+
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum += 1) {
+      const page = await pdf.getPage(pageNum);
+      const viewport = page.getViewport({ scale: 1.4 });
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      canvas.height = viewport.height;
+      canvas.width = viewport.width;
+      await page.render({ canvasContext: context, viewport }).promise;
+      pages.push({
+        pageNumber: pageNum,
+        width: canvas.width,
+        height: canvas.height,
+        dataUrl: canvas.toDataURL('image/png')
+      });
     }
 
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = '';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
+    setPdfPages(pages);
   }
+
+  useEffect(() => {
+    if (!draggingStamp) {
+      return undefined;
+    }
+
+    function handlePointerMove(event) {
+      if (!pdfContainerRef.current) return;
+      const containerRect = pdfContainerRef.current.getBoundingClientRect();
+      const stampEl = stampRef.current;
+      const stampWidth = stampEl?.offsetWidth || 0;
+      const stampHeight = stampEl?.offsetHeight || 0;
+      const nextX = event.clientX - containerRect.left - dragOffsetRef.current.x;
+      const nextY = event.clientY - containerRect.top - dragOffsetRef.current.y;
+
+      const clampedX = Math.max(0, Math.min(containerRect.width - stampWidth, nextX));
+      const clampedY = Math.max(0, Math.min(containerRect.height - stampHeight, nextY));
+      setStampPosition({x: clampedX, y: clampedY});
+    }
+
+    function handlePointerUp(event) {
+      if (stampRef.current?.releasePointerCapture) {
+        try {
+          stampRef.current.releasePointerCapture(event.pointerId);
+        } catch (err) {
+          // ignore release errors
+        }
+      }
+      setDraggingStamp(false);
+    }
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [draggingStamp]);
+
+  const handleStampPointerDown = (event) => {
+    if (!pdfContainerRef.current) return;
+    const stampRect = event.currentTarget.getBoundingClientRect();
+    dragOffsetRef.current = {
+      x: event.clientX - stampRect.left,
+      y: event.clientY - stampRect.top
+    };
+    setDraggingStamp(true);
+    if (event.currentTarget.setPointerCapture) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch (err) {
+        // ignore capture errors
+      }
+    }
+    event.preventDefault();
+  };
 
   const row = (label, key, type='text') => (
     <div style={{display:'grid', gridTemplateColumns:'220px 1fr', gap:12, alignItems:'center', marginBottom:12}}>
@@ -110,9 +218,61 @@ export default function ConfirmationPage() {
         {row('备注','remark','textarea')}
 
         <div style={{marginTop:20}}>
-          <button type="submit" style={{padding:'10px 16px', fontSize:16}}>生成 DOCX</button>
+          <button type="submit" style={{padding:'10px 16px', fontSize:16}} disabled={loading}>
+            {loading ? '生成中…' : '生成预览'}
+          </button>
         </div>
       </form>
+
+      {error && (
+        <div style={{marginTop:16, color:'#c00'}}>{error}</div>
+      )}
+
+      {pdfPages.length > 0 && (
+        <div
+          ref={pdfContainerRef}
+          style={{
+            position:'relative',
+            marginTop:24,
+            border:'1px solid #ddd',
+            padding:12,
+            borderRadius:8,
+            background:'#f8f8f8'
+          }}
+        >
+          {pdfPages.map(page => (
+            <img
+              key={page.pageNumber}
+              src={page.dataUrl}
+              alt={`PDF 第 ${page.pageNumber} 页`}
+              style={{
+                display:'block',
+                width:'100%',
+                height:'auto',
+                marginBottom:16,
+                boxShadow:'0 4px 12px rgba(0,0,0,0.1)'
+              }}
+            />
+          ))}
+
+          <img
+            ref={stampRef}
+            src="/stamp.svg"
+            alt="印章"
+            onPointerDown={handleStampPointerDown}
+            draggable={false}
+            style={{
+              position:'absolute',
+              top: stampPosition.y,
+              left: stampPosition.x,
+              width: 140,
+              cursor: draggingStamp ? 'grabbing' : 'grab',
+              userSelect:'none',
+              touchAction:'none'
+            }}
+          />
+        </div>
+      )}
     </main>
   );
 }

--- a/docgen-form/package.json
+++ b/docgen-form/package.json
@@ -12,6 +12,7 @@
     "docx-templates": "4.14.1",
     "jszip": "3.10.1",
     "next": "14.2.5",
+    "pdfjs-dist": "3.11.174",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   }

--- a/docgen-form/public/stamp.svg
+++ b/docgen-form/public/stamp.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <defs>
+    <style>
+      .outline { fill: none; stroke: #c62828; stroke-width: 8; }
+      .text-main { font: bold 32px 'Arial', sans-serif; letter-spacing: 4px; fill: #c62828; }
+      .text-sub { font: 16px 'Arial', sans-serif; letter-spacing: 2px; fill: #c62828; }
+    </style>
+  </defs>
+  <circle class="outline" cx="100" cy="100" r="88" />
+  <circle class="outline" cx="100" cy="100" r="70" stroke-dasharray="12 12" />
+  <g text-anchor="middle">
+    <text class="text-main" x="100" y="105">VANKA</text>
+    <text class="text-sub" x="100" y="135">CONFIRMED</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- update the confirmation page to request `/api/preview`, render the returned PDF blob with pdfjs, and reset preview state while loading
- add interactive client-side state for loading/errors plus an absolutely positioned stamp image that can be dragged across the rendered preview
- add pdfjs-dist as a dependency and include a reusable SVG stamp asset in the public folder

## Testing
- npm install pdfjs-dist *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/pdfjs-dist)*

------
https://chatgpt.com/codex/tasks/task_e_68c952c5171483218577d54184784980