### PR TITLE
Add helper context for docx templates

### DIFF
--- a/docgen-form/lib/generator.js
+++ b/docgen-form/lib/generator.js
@@ -24,9 +24,26 @@ async function normalizeDocxDelimiters(docxBuffer) {
   return Buffer.from(await zip.generateAsync({type:'nodebuffer'}));
 }
 
+const printable = value => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number' && !Number.isFinite(value)) return '';
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '' : value.toISOString();
+  }
+  return String(value);
+};
+
+const defaultJsContext = {
+  c: (...args) => args.map(printable).join('')
+};
+
 export async function generateDocxBuffer({templatePath, payload}) {
   const buf = await readFile(templatePath);
   const normalized = await normalizeDocxDelimiters(buf);
-  const out = await createReport({ template: normalized, data: payload || {} });
+  const out = await createReport({
+    template: normalized,
+    data: payload || {},
+    additionalJsContext: defaultJsContext
+  });
   return Buffer.from(out);
 }


### PR DESCRIPTION
## Summary
- add printable formatting helper for values flowing into docx templates
- register a default `c()` helper so templates calling it no longer crash

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95b3ffadc8321b6d7d19cd5b4abd3