### PR TITLE
Install LibreOffice in runtime Docker image

### DIFF
--- a/docgen-form/Dockerfile
+++ b/docgen-form/Dockerfile
@@ -11,6 +11,9 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+# Install LibreOffice for DOCX to PDF conversion in the preview API
+RUN apk add --no-cache libreoffice
+
 # 拷贝 Next 独立产物
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static


### PR DESCRIPTION
## Summary
- install LibreOffice in the runtime Docker image so the preview API can convert DOCX files to PDF

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca9f9b9c1c832188631eb390a85828