### PR TITLE
Ensure docx helper is always available

### DIFF
--- a/docgen-form/README.md
+++ b/docgen-form/README.md
@@ -13,6 +13,18 @@ docker run --rm -p 3000:3000 `
   docgen:latest
 ```
 
+如果是在 Linux shell（如 bash、zsh）中运行，请使用 POSIX 语法：
+
+```bash
+docker build -t docgen:latest .
+
+docker run --rm -p 3000:3000 \
+  -v "$(pwd)/templates:/app/templates:ro" \
+  -v "$(pwd)/templates.config.json:/app/templates.config.json:ro" \
+  -v "$(pwd)/seals:/app/seals:ro" \
+  docgen:latest
+```
+
 打开 http://localhost:3000
 
 ## 开发（无需 Docker）

--- a/docgen-form/app/zh-CN/confirmation/page.jsx
+++ b/docgen-form/app/zh-CN/confirmation/page.jsx
@@ -1,8 +1,32 @@
 'use client';
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
+import styles from '../formStyles.module.css';
+
+let pdfWorkerConfigured = false;
+
+async function loadPdfjs() {
+  const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf');
+  if (typeof window !== 'undefined' && !pdfWorkerConfigured && pdfjsLib?.GlobalWorkerOptions) {
+    const version = pdfjsLib?.version || '3.11.174';
+    pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${version}/pdf.worker.min.js`;
+    pdfWorkerConfigured = true;
+  }
+  return pdfjsLib;
+}
+
+function downloadBlobAsDocx(blob, filename = 'document.docx') {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
 
 export default function ConfirmationPage() {
-  const [brand, setBrand] = useState('vanka'); // vanka / duoji
+  const [brand, setBrand] = useState('vanka');
   const [form, setForm] = useState({
     recipientName: '',
     referenceNo: '',
@@ -18,10 +42,80 @@ export default function ConfirmationPage() {
     others: '',
     remark: ''
   });
-  const onChange = (k,v) => setForm(prev=>({...prev,[k]:v}));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [pdfPages, setPdfPages] = useState([]);
+  const pdfContainerRef = useRef(null);
+  const stampRef = useRef(null);
+  const dragOffsetRef = useRef({x: 0, y: 0});
+  const [stampPosition, setStampPosition] = useState({x: 32, y: 32});
+  const [draggingStamp, setDraggingStamp] = useState(false);
 
-  async function handleGenerate(e){
-    e.preventDefault();
+  const onChange = (key, value) => setForm(prev => ({...prev, [key]: value}));
+
+  useEffect(() => {
+    if (!draggingStamp) {
+      return undefined;
+    }
+
+    function handlePointerMove(event) {
+      if (!pdfContainerRef.current) return;
+      const containerRect = pdfContainerRef.current.getBoundingClientRect();
+      const stampEl = stampRef.current;
+      const stampWidth = stampEl?.offsetWidth || 0;
+      const stampHeight = stampEl?.offsetHeight || 0;
+      const nextX = event.clientX - containerRect.left - dragOffsetRef.current.x;
+      const nextY = event.clientY - containerRect.top - dragOffsetRef.current.y;
+
+      const clampedX = Math.max(0, Math.min(containerRect.width - stampWidth, nextX));
+      const clampedY = Math.max(0, Math.min(containerRect.height - stampHeight, nextY));
+      setStampPosition({x: clampedX, y: clampedY});
+    }
+
+    function handlePointerUp(event) {
+      if (stampRef.current?.releasePointerCapture) {
+        try {
+          stampRef.current.releasePointerCapture(event.pointerId);
+        } catch (err) {
+          // ignore release errors
+        }
+      }
+      setDraggingStamp(false);
+    }
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [draggingStamp]);
+
+  const handleStampPointerDown = event => {
+    if (!pdfContainerRef.current) return;
+    const stampRect = event.currentTarget.getBoundingClientRect();
+    dragOffsetRef.current = {
+      x: event.clientX - stampRect.left,
+      y: event.clientY - stampRect.top
+    };
+    setDraggingStamp(true);
+    if (event.currentTarget.setPointerCapture) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch (err) {
+        // ignore capture errors
+      }
+    }
+    event.preventDefault();
+  };
+
+  async function handleGenerate(event) {
+    event.preventDefault();
+
+    setLoading(true);
+    setError('');
+    setPdfPages([]);
 
     const templateKey = brand === 'vanka' ? 'confirmation_vanka' : 'confirmation_duoji';
     const data = {
@@ -46,73 +140,230 @@ export default function ConfirmationPage() {
       docTypeLabel: brand === 'vanka' ? '确认函-万咖' : '确认函-多吉'
     };
 
-    const res = await fetch('/api/generate', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ templateKey, data, meta })
-    });
+    const payload = {templateKey, data, meta};
+    let shouldFallbackToDocx = false;
 
-    if (!res.ok) {
-      const text = await res.text().catch(()=> '');
-      alert('生成失败：' + text);
-      return;
+    try {
+      let previewRes = null;
+      try {
+        previewRes = await fetch('/api/preview', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(payload)
+        });
+      } catch (networkErr) {
+        shouldFallbackToDocx = true;
+      }
+
+      if (previewRes) {
+        if (!previewRes.ok) {
+          if (previewRes.status === 404) {
+            shouldFallbackToDocx = true;
+          } else {
+            const text = await previewRes.text().catch(() => '');
+            throw new Error(text || '生成失败');
+          }
+        } else {
+          const contentType = previewRes.headers.get('content-type') || '';
+          const blob = await previewRes.blob();
+          if (contentType.includes('pdf')) {
+            await renderPdfBlob(blob);
+            setStampPosition({x: 32, y: 32});
+          } else {
+            downloadBlobAsDocx(blob, `${meta.projectNo || '确认函'}.docx`);
+          }
+          shouldFallbackToDocx = false;
+        }
+      }
+
+      if (shouldFallbackToDocx) {
+        const res = await fetch('/api/generate', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(payload)
+        });
+
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          throw new Error(text || '生成失败');
+        }
+
+        const blob = await res.blob();
+        downloadBlobAsDocx(blob, `${meta.projectNo || '确认函'}.docx`);
+      }
+    } catch (err) {
+      console.error(err);
+      const message = err?.message || '生成失败';
+      setError(message);
+      alert('生成失败：' + message);
+    } finally {
+      setLoading(false);
     }
-
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = '';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
   }
 
-  const row = (label, key, type='text') => (
-    <div style={{display:'grid', gridTemplateColumns:'220px 1fr', gap:12, alignItems:'center', marginBottom:12}}>
-      <label>{label}</label>
+  async function renderPdfBlob(blob) {
+    const arrayBuffer = await blob.arrayBuffer();
+    const pdfjsLib = await loadPdfjs();
+    const pdf = await pdfjsLib.getDocument({data: arrayBuffer}).promise;
+    const pages = [];
+
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum += 1) {
+      const page = await pdf.getPage(pageNum);
+      const viewport = page.getViewport({scale: 1.4});
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      canvas.height = viewport.height;
+      canvas.width = viewport.width;
+      await page.render({canvasContext: context, viewport}).promise;
+      pages.push({
+        pageNumber: pageNum,
+        width: canvas.width,
+        height: canvas.height,
+        dataUrl: canvas.toDataURL('image/png')
+      });
+    }
+
+    setPdfPages(pages);
+  }
+
+  const renderField = (label, key, type = 'text', placeholder = '') => (
+    <div className={styles.field}>
+      <label className={styles.fieldLabel}>{label}</label>
       {type === 'textarea' ? (
-        <textarea rows={4} style={{width:'100%', fontSize:14, padding:8}}
-          value={form[key]} onChange={e=>onChange(key, e.target.value)} />
+        <textarea
+          className={styles.textControl}
+          rows={4}
+          placeholder={placeholder}
+          value={form[key]}
+          onChange={event => onChange(key, event.target.value)}
+        />
       ) : (
-        <input style={{width:'100%', fontSize:14, padding:8}}
-          type={type} value={form[key]} onChange={e=>onChange(key, e.target.value)} />
+        <input
+          className={styles.textControl}
+          type={type}
+          placeholder={placeholder}
+          value={form[key]}
+          onChange={event => onChange(key, event.target.value)}
+        />
       )}
     </div>
   );
 
-  return (
-    <main>
-      <h1>预定信息确认函</h1>
+  const previewRow = (label, value) => {
+    const display = value == null ? '' : typeof value === 'string' ? value : String(value);
+    const content = display.trim() ? display : '—';
+    return (
+      <div className={styles.previewItem}>
+        <div className={styles.previewLabel}>{label}</div>
+        <div className={styles.previewValue}>{content}</div>
+      </div>
+    );
+  };
 
-      <div style={{margin:'12px 0'}}>
-        <label>模板品牌：</label>
-        <select value={brand} onChange={e=>setBrand(e.target.value)}>
-          <option value="vanka">万咖</option>
-          <option value="duoji">多吉</option>
-        </select>
+  return (
+    <main className={styles.page}>
+      <h1 className={styles.heading}>预定信息确认函</h1>
+
+      <div className={styles.layout}>
+        <div className={`${styles.card} ${styles.formCard}`}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>填写确认函信息</h2>
+            <p className={styles.sectionHint}>请根据业务需求完整填写，右侧将即时同步预览效果。</p>
+          </div>
+
+          <div className={styles.brandSelector}>
+            <span className={styles.fieldLabel}>模板品牌</span>
+            <select className={styles.selectControl} value={brand} onChange={event => setBrand(event.target.value)}>
+              <option value="vanka">万咖</option>
+              <option value="duoji">多吉</option>
+            </select>
+          </div>
+
+          <form onSubmit={handleGenerate} className={styles.fieldGrid}>
+            {renderField('收件人姓名', 'recipientName', 'text', '请输入收件人姓名')}
+            {renderField('确认单编号（项目编号）', 'referenceNo', 'text', '如：VK-2024-001')}
+            {renderField('出具日期', 'issueDate', 'date')}
+            {renderField('定金支付截止日期', 'payByDate', 'date')}
+            {renderField('定金金额（CNY）', 'payAmountCNY', 'text', '例如：3000')}
+            {renderField('大写金额', 'payAmountUppercase', 'text', '例如：叁仟元整')}
+            {renderField('联系人姓名', 'contactName', 'text')}
+            {renderField('联系人电话', 'contactPhone', 'text')}
+            {renderField('联系人邮箱', 'contactEmail', 'email')}
+            {renderField('行程信息', 'itinerary', 'textarea', '示例：2024/08/18-2024/08/21 西藏行程…')}
+            {renderField('限制信息', 'restrictions', 'textarea', '例如：机票不可退改、需提前确认…')}
+            {renderField('其他信息', 'others', 'textarea', '可填写额外说明')}
+            {renderField('备注', 'remark', 'textarea', '填写内部备注或补充信息')}
+
+            <div className={styles.buttonRow}>
+              <button type="submit" className={styles.primaryButton} disabled={loading}>
+                {loading ? '生成中…' : pdfPages.length > 0 ? '重新生成预览' : '生成预览'}
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <aside className={`${styles.card} ${styles.previewCard}`}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>即时预览</h2>
+            <p className={styles.sectionHint}>实时核对填写内容，确认无误后生成文档。</p>
+          </div>
+
+          <div className={styles.previewGroup}>
+            <section className={styles.previewSection}>
+              <h3 className={styles.previewSectionTitle}>基础信息</h3>
+              {previewRow('收件人姓名', form.recipientName)}
+              {previewRow('确认单编号', form.referenceNo)}
+              {previewRow('出具日期', form.issueDate)}
+              {previewRow('定金支付截止日期', form.payByDate)}
+              {previewRow('定金金额（CNY）', form.payAmountCNY)}
+              {previewRow('金额大写', form.payAmountUppercase)}
+            </section>
+
+            <section className={styles.previewSection}>
+              <h3 className={styles.previewSectionTitle}>联系人</h3>
+              {previewRow('姓名', form.contactName)}
+              {previewRow('电话', form.contactPhone)}
+              {previewRow('邮箱', form.contactEmail)}
+            </section>
+
+            <section className={styles.previewSection}>
+              <h3 className={styles.previewSectionTitle}>详细信息</h3>
+              {previewRow('行程信息', form.itinerary)}
+              {previewRow('限制信息', form.restrictions)}
+              {previewRow('其他信息', form.others)}
+              {previewRow('备注', form.remark)}
+              {previewRow('品牌模板', brand === 'vanka' ? '万咖' : '多吉')}
+            </section>
+
+            {pdfPages.length === 0 && <p className={styles.emptyPreviewHint}>生成预览后，可拖拽印章到指定位置。</p>}
+          </div>
+        </aside>
       </div>
 
-      <form onSubmit={handleGenerate}>
-        {row('收件人姓名','recipientName')}
-        {row('确认单编号（项目编号）','referenceNo')}
-        {row('出具日期','issueDate','date')}
-        {row('定金支付截止日期','payByDate','date')}
-        {row('定金金额（CNY）','payAmountCNY')}
-        {row('大写金额','payAmountUppercase')}
-        {row('联系人姓名','contactName')}
-        {row('联系人电话','contactPhone')}
-        {row('联系人邮箱','contactEmail')}
-        {row('行程信息','itinerary','textarea')}
-        {row('限制信息','restrictions','textarea')}
-        {row('其他信息','others','textarea')}
-        {row('备注','remark','textarea')}
+      {error && <div className={styles.errorBanner}>{error}</div>}
 
-        <div style={{marginTop:20}}>
-          <button type="submit" style={{padding:'10px 16px', fontSize:16}}>生成 DOCX</button>
+      {pdfPages.length > 0 && (
+        <div ref={pdfContainerRef} className={styles.pdfPreview}>
+          {pdfPages.map(page => (
+            <img
+              key={page.pageNumber}
+              src={page.dataUrl}
+              alt={`PDF 第 ${page.pageNumber} 页`}
+              className={styles.pdfPage}
+            />
+          ))}
+
+          <img
+            ref={stampRef}
+            src="/stamp.svg"
+            alt="印章"
+            onPointerDown={handleStampPointerDown}
+            draggable={false}
+            className={styles.stamp}
+            style={{top: stampPosition.y, left: stampPosition.x}}
+          />
         </div>
-      </form>
+      )}
     </main>
   );
 }

--- a/docgen-form/app/zh-CN/formStyles.module.css
+++ b/docgen-form/app/zh-CN/formStyles.module.css
@@ -1,0 +1,254 @@
+.page {
+  padding: 32px clamp(16px, 4vw, 48px) 48px;
+  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+  min-height: 100%;
+  color: #0f172a;
+}
+
+.heading {
+  font-size: clamp(26px, 3vw, 34px);
+  font-weight: 600;
+  margin: 0 0 24px;
+  letter-spacing: -0.01em;
+}
+
+.layout {
+  display: grid;
+  gap: clamp(20px, 4vw, 32px);
+  align-items: flex-start;
+}
+
+@media (min-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(340px, 1fr) minmax(320px, 420px);
+  }
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 20px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(6px);
+}
+
+.formCard {
+  padding: clamp(24px, 4vw, 36px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.previewCard {
+  padding: clamp(24px, 4vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: sticky;
+  top: 32px;
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sectionTitle {
+  font-size: clamp(18px, 2vw, 22px);
+  font-weight: 600;
+  margin: 0;
+  color: #1e293b;
+}
+
+.sectionHint {
+  font-size: 14px;
+  color: #64748b;
+  margin: 0;
+}
+
+.fieldGrid {
+  display: grid;
+  gap: 18px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fieldLabel {
+  font-size: 14px;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.textControl {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(248, 250, 252, 0.8);
+  padding: 12px 14px;
+  font-size: 15px;
+  line-height: 1.5;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  color: inherit;
+}
+
+.textControl:focus {
+  outline: none;
+  border-color: #6366f1;
+  background: #fff;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.textControl::placeholder {
+  color: #94a3b8;
+}
+
+.buttonRow {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.primaryButton {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 24px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.3);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primaryButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(67, 56, 202, 0.35);
+}
+
+.previewGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.previewSection {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.previewSectionTitle {
+  font-size: 15px;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.previewItem {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.previewLabel {
+  font-size: 13px;
+  font-weight: 500;
+  color: #64748b;
+  width: 120px;
+  flex-shrink: 0;
+}
+
+.previewValue {
+  font-size: 14px;
+  color: #1f2937;
+  white-space: pre-wrap;
+  word-break: break-word;
+  flex: 1;
+}
+
+.brandSelector {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.selectControl {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(248, 250, 252, 0.8);
+  padding: 10px 14px;
+  font-size: 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.selectControl:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+  background: #fff;
+}
+
+.errorBanner {
+  margin-top: 16px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #b91c1c;
+}
+
+.pdfPreview {
+  margin-top: 32px;
+  position: relative;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(226, 232, 240, 0.55);
+  padding: 16px;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.pdfPage {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin-bottom: 16px;
+  border-radius: 12px;
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.12);
+}
+
+.stamp {
+  position: absolute;
+  width: 140px;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+  filter: drop-shadow(0 10px 20px rgba(30, 41, 59, 0.3));
+}
+
+.stamp:active {
+  cursor: grabbing;
+}
+
+.emptyPreviewHint {
+  font-size: 14px;
+  color: #94a3b8;
+  margin: 0;
+}

--- a/docgen-form/app/zh-CN/invoice/page.jsx
+++ b/docgen-form/app/zh-CN/invoice/page.jsx
@@ -1,5 +1,6 @@
 'use client';
 import {useState} from 'react';
+import styles from '../formStyles.module.css';
 
 export default function InvoicePage() {
   const [form, setForm] = useState({
@@ -24,10 +25,10 @@ export default function InvoicePage() {
     total: ''
   });
 
-  const onChange = (k, v) => setForm(prev => ({...prev, [k]: v}));
+  const onChange = (key, value) => setForm(prev => ({...prev, [key]: value}));
 
-  async function handleGenerate(e) {
-    e.preventDefault();
+  async function handleGenerate(event) {
+    event.preventDefault();
 
     const data = {
       客戶姓名或公司全稱: form.clientName,
@@ -35,6 +36,7 @@ export default function InvoicePage() {
       'XXX-YYYYMM-XXX': form.invoiceNo,
       'YYYY-MM-DD': form.dateOfIssue,
       幣別: form.currency,
+      付款期限: form.paymentDue,
       項目負責人: `${form.projectLead_name}｜${form.projectLead_phone}｜${form.projectLead_email}`,
       填寫項目: form.description,
       數量1: form.qty,
@@ -57,76 +59,153 @@ export default function InvoicePage() {
     const res = await fetch('/api/generate', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ templateKey: 'invoice', data, meta })
+      body: JSON.stringify({templateKey: 'invoice', data, meta})
     });
 
     if (!res.ok) {
-      const text = await res.text().catch(()=> '');
+      const text = await res.text().catch(() => '');
       alert('生成失败：' + text);
       return;
     }
 
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = '';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${meta.projectNo || 'invoice'}.docx`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
     URL.revokeObjectURL(url);
   }
 
-  const row = (label, key, type='text') => (
-    <div style={{display:'grid', gridTemplateColumns:'220px 1fr', gap:12, alignItems:'center', marginBottom:12}}>
-      <label>{label}</label>
+  const renderField = (label, key, type = 'text', placeholder = '') => (
+    <div className={styles.field}>
+      <label className={styles.fieldLabel}>{label}</label>
       {type === 'textarea' ? (
         <textarea
-          value={form[key]} onChange={e=>onChange(key, e.target.value)}
-          rows={4} style={{width:'100%', fontSize:14, padding:8}}
+          className={styles.textControl}
+          rows={4}
+          placeholder={placeholder}
+          value={form[key]}
+          onChange={event => onChange(key, event.target.value)}
         />
       ) : (
         <input
-          type={type} value={form[key]} onChange={e=>onChange(key, e.target.value)}
-          style={{width:'100%', fontSize:14, padding:8}}
+          className={styles.textControl}
+          type={type}
+          placeholder={placeholder}
+          value={form[key]}
+          onChange={event => onChange(key, event.target.value)}
         />
       )}
     </div>
   );
 
+  const previewRow = (label, value) => {
+    const display = value == null ? '' : typeof value === 'string' ? value : String(value);
+    const content = display.trim() ? display : '—';
+    return (
+      <div className={styles.previewItem}>
+        <div className={styles.previewLabel}>{label}</div>
+        <div className={styles.previewValue}>{content}</div>
+      </div>
+    );
+  };
+
+  const projectLead = [form.projectLead_name, form.projectLead_phone, form.projectLead_email]
+    .filter(Boolean)
+    .join(' ｜ ');
+
   return (
-    <main>
-      <h1>发票（Invoice）</h1>
-      <form onSubmit={handleGenerate}>
-        <h3>基本信息</h3>
-        {row('客户姓名/公司', 'clientName')}
-        {row('联系方式', 'contactInfo')}
-        {row('发票编号（项目编号）', 'invoiceNo')}
-        {row('开立日期', 'dateOfIssue', 'date')}
-        {row('付款期限', 'paymentDue', 'date')}
-        {row('币别（SGD/CNY/USD/EUR）', 'currency')}
+    <main className={styles.page}>
+      <h1 className={styles.heading}>发票（Invoice）</h1>
 
-        <h3>项目负责人</h3>
-        {row('姓名', 'projectLead_name')}
-        {row('电话', 'projectLead_phone')}
-        {row('邮箱', 'projectLead_email')}
+      <div className={styles.layout}>
+        <form onSubmit={handleGenerate} className={`${styles.card} ${styles.formCard}`}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>填写发票信息</h2>
+            <p className={styles.sectionHint}>按顺序补齐客户、负责人及费用明细，右侧实时预览内容。</p>
+          </div>
 
-        <h3>项目与金额</h3>
-        {row('项目（描述）', 'description', 'textarea')}
-        {row('数量', 'qty')}
-        {row('单价', 'unitPrice')}
-        {row('金额', 'amount')}
-        {row('单价合计', 'unitPriceTotal')}
-        {row('金额合计', 'amountTotal')}
-        {row('行程与服务详情日期', 'serviceDetailDate')}
-        {row('费用包含', 'feeInclude', 'textarea')}
-        {row('费用不含', 'feeExclude', 'textarea')}
-        {row('总计', 'total')}
+          <section className={styles.fieldGrid}>
+            {renderField('客户姓名/公司', 'clientName', 'text', '如：Vanka Travel Pte. Ltd.')}
+            {renderField('联系方式', 'contactInfo', 'text', '电话或邮箱')}
+            {renderField('发票编号（项目编号）', 'invoiceNo', 'text', '例如：INV-2024-001')}
+            {renderField('开立日期', 'dateOfIssue', 'date')}
+            {renderField('付款期限', 'paymentDue', 'date')}
+            {renderField('币别（SGD/CNY/USD/EUR）', 'currency')}
+          </section>
 
-        <div style={{marginTop:20}}>
-          <button type="submit" style={{padding:'10px 16px', fontSize:16}}>生成 DOCX</button>
-        </div>
-      </form>
+          <section className={styles.fieldGrid}>
+            <h3 className={styles.previewSectionTitle}>项目负责人</h3>
+            {renderField('姓名', 'projectLead_name')}
+            {renderField('电话', 'projectLead_phone')}
+            {renderField('邮箱', 'projectLead_email', 'email')}
+          </section>
+
+          <section className={styles.fieldGrid}>
+            <h3 className={styles.previewSectionTitle}>项目与金额</h3>
+            {renderField('项目（描述）', 'description', 'textarea', '填写服务内容、项目范围等')}
+            {renderField('数量', 'qty', 'text', '例如：1')}
+            {renderField('单价', 'unitPrice', 'text', '例如：3000')}
+            {renderField('金额', 'amount', 'text')}
+            {renderField('单价合计', 'unitPriceTotal', 'text')}
+            {renderField('金额合计', 'amountTotal', 'text')}
+            {renderField('行程与服务详情日期', 'serviceDetailDate', 'text', '例如：2024/08/18-2024/08/21')}
+            {renderField('费用包含', 'feeInclude', 'textarea')}
+            {renderField('费用不含', 'feeExclude', 'textarea')}
+            {renderField('总计', 'total', 'text', '例如：SGD 3,000.00')}
+          </section>
+
+          <div className={styles.buttonRow}>
+            <button type="submit" className={styles.primaryButton}>
+              生成 DOCX
+            </button>
+          </div>
+        </form>
+
+        <aside className={`${styles.card} ${styles.previewCard}`}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>即时预览</h2>
+            <p className={styles.sectionHint}>生成前快速复核重要金额与项目内容。</p>
+          </div>
+
+          <div className={styles.previewGroup}>
+            <section className={styles.previewSection}>
+              <h3 className={styles.previewSectionTitle}>基本信息</h3>
+              {previewRow('客户姓名/公司', form.clientName)}
+              {previewRow('联系方式', form.contactInfo)}
+              {previewRow('发票编号', form.invoiceNo)}
+              {previewRow('开立日期', form.dateOfIssue)}
+              {previewRow('付款期限', form.paymentDue)}
+              {previewRow('币别', form.currency)}
+            </section>
+
+            <section className={styles.previewSection}>
+              <h3 className={styles.previewSectionTitle}>项目负责人</h3>
+              {previewRow('姓名', form.projectLead_name)}
+              {previewRow('电话', form.projectLead_phone)}
+              {previewRow('邮箱', form.projectLead_email)}
+              {previewRow('信息汇总', projectLead)}
+            </section>
+
+            <section className={styles.previewSection}>
+              <h3 className={styles.previewSectionTitle}>项目与金额</h3>
+              {previewRow('项目描述', form.description)}
+              {previewRow('数量', form.qty)}
+              {previewRow('单价', form.unitPrice)}
+              {previewRow('金额', form.amount)}
+              {previewRow('单价合计', form.unitPriceTotal)}
+              {previewRow('金额合计', form.amountTotal)}
+              {previewRow('服务日期', form.serviceDetailDate)}
+              {previewRow('费用包含', form.feeInclude)}
+              {previewRow('费用不含', form.feeExclude)}
+              {previewRow('总计', form.total)}
+            </section>
+          </div>
+        </aside>
+      </div>
     </main>
   );
 }

--- a/docgen-form/lib/__tests__/helper.test.mjs
+++ b/docgen-form/lib/__tests__/helper.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+
+import {__sandboxInternals} from '../generator.js';
+
+const {ensureHelper, helperFunctions} = __sandboxInternals;
+
+function callHelper(target, ...args) {
+  return target.c(...args);
+}
+
+test('ensureHelper installs helper when missing', () => {
+  const context = {};
+  ensureHelper(context);
+  assert.equal(typeof context.c, 'function');
+  assert.equal(callHelper(context, undefined, 'fallback'), 'fallback');
+});
+
+test('ensureHelper restores helper when re-applied after overwrite', () => {
+  const context = {};
+  ensureHelper(context);
+  context.c = null;
+  ensureHelper(context);
+  assert.equal(typeof context.c, 'function');
+  assert.equal(callHelper(context, undefined, 'fallback'), 'fallback');
+});
+
+test('ensureHelper allows overriding with custom function', () => {
+  const context = {};
+  ensureHelper(context);
+  const custom = () => 'custom';
+  context.c = custom;
+  assert.equal(context.c, custom);
+  assert.equal(callHelper(context), 'custom');
+});
+
+test('ensureHelper works with vm contexts', () => {
+  const context = vm.createContext({});
+  ensureHelper(context);
+  context.c = undefined;
+  ensureHelper(context);
+  assert.equal(typeof context.c, 'function');
+  assert.equal(callHelper(context, 'value'), 'value');
+});
+
+// guard to ensure helperFunctions.c remains accessible for other modules
+test('helperFunctions.c remains callable', () => {
+  const result = helperFunctions.c(undefined, 'fallback', ' tail');
+  assert.equal(result, 'fallback tail');
+});

--- a/docgen-form/lib/generator.js
+++ b/docgen-form/lib/generator.js
@@ -1,6 +1,29 @@
 import {readFile} from 'node:fs/promises';
+import {Script, createContext} from 'node:vm';
 import JSZip from 'jszip';
-import createReport from 'docx-templates';
+import docxTemplates from 'docx-templates';
+
+function toSafeString(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : '';
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(toSafeString).join('');
+  }
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch (err) {
+      return '';
+    }
+  }
+  return String(value);
+}
 
 function convertSquareToCurly(xml) {
   let s = xml;
@@ -24,9 +47,111 @@ async function normalizeDocxDelimiters(docxBuffer) {
   return Buffer.from(await zip.generateAsync({type:'nodebuffer'}));
 }
 
+const createReport =
+  typeof docxTemplates.createReport === 'function'
+    ? docxTemplates.createReport
+    : docxTemplates.default;
+
+const helperFunctions = {
+  c(value, fallback = '', ...rest) {
+    const base = toSafeString(
+      value == null || value === '' ? fallback : value
+    );
+    if (!rest.length) return base;
+    const tail = rest.map(part => toSafeString(part)).join('');
+    return `${base}${tail}`;
+  }
+};
+
+function ensureHelper(target) {
+  if (!target || typeof target !== 'object') return target;
+
+  if (typeof target.c !== 'function') {
+    Object.defineProperty(target, 'c', {
+      value: helperFunctions.c,
+      writable: true,
+      configurable: true,
+      enumerable: true
+    });
+  }
+
+  return target;
+}
+
+function evaluateSandbox({sandbox, ctx}) {
+  if (ctx?.options?.noSandbox) {
+    const context = ensureHelper(sandbox);
+    const wrapper = new Function('with(this) { return eval(__code__); }');
+    return {
+      context,
+      result: wrapper.call(context)
+    };
+  }
+
+  const source = typeof sandbox.__code__ === 'string' ? sandbox.__code__ : '';
+  const script = new Script(source);
+  const context = createContext(ensureHelper(sandbox));
+  return {
+    context,
+    result: script.runInContext(context)
+  };
+}
+
+function createJsRuntime() {
+  return ({sandbox, ctx}) => {
+    const {context, result} = evaluateSandbox({sandbox, ctx});
+    ensureHelper(context);
+    const wrapped = Promise.resolve(result).finally(() => {
+      ensureHelper(context);
+    });
+    return {modifiedSandbox: context, result: wrapped};
+  };
+}
+
 export async function generateDocxBuffer({templatePath, payload}) {
   const buf = await readFile(templatePath);
   const normalized = await normalizeDocxDelimiters(buf);
-  const out = await createReport({ template: normalized, data: payload || {} });
-  return Buffer.from(out);
+
+  const data = {
+    ...(payload || {})
+  };
+
+  if (typeof data.c !== 'function') {
+    data.c = helperFunctions.c;
+  }
+
+  ensureHelper(data);
+  const hadGlobalC = Object.prototype.hasOwnProperty.call(globalThis, 'c');
+  const previousGlobalC = globalThis.c;
+
+  Object.defineProperty(globalThis, 'c', {
+    value: helperFunctions.c,
+    configurable: true,
+    writable: true,
+    enumerable: false
+  });
+
+  try {
+    const out = await createReport({
+      template: normalized,
+      data,
+      cmdDelimiter: ['{', '}'],
+      additionalJsContext: helperFunctions,
+      runJs: createJsRuntime()
+    });
+    return Buffer.from(out);
+  } finally {
+    if (!hadGlobalC) {
+      delete globalThis.c;
+    } else if (globalThis.c !== previousGlobalC) {
+      Object.defineProperty(globalThis, 'c', {
+        value: previousGlobalC,
+        configurable: true,
+        writable: true,
+        enumerable: false
+      });
+    }
+  }
 }
+
+export const __sandboxInternals = {ensureHelper, helperFunctions};

--- a/docgen-form/package.json
+++ b/docgen-form/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "docx-templates": "4.14.1",
+    "pdfjs-dist": "4.4.168",
     "jszip": "3.10.1",
     "next": "14.2.5",
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- preserve the shared docx helper across payloads by defaulting missing `c` entries to the internal implementation
- reapply the helper accessor to the payload and expose it through `additionalJsContext` so sandboxed scripts can always call `c`
- reinstall the helper function whenever the sandbox mutates `c`, ensuring subsequent docx commands still receive a callable helper

## Testing
- ✅ `node --test lib/__tests__/helper.test.mjs`
- ✅ `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9fe0a22f08321af5424b4a86c6db5