### PR TITLE
Refresh homepage styling and add new template entries

### DIFF
--- a/docgen-form/app/home.module.css
+++ b/docgen-form/app/home.module.css
@@ -1,78 +1,122 @@
 .page {
+  position: relative;
   min-height: 100vh;
-  padding: clamp(32px, 6vw, 72px) clamp(20px, 6vw, 64px);
-  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 20%, rgba(99, 102, 241, 0.15), transparent 60%),
-    #f1f5f9;
+  padding: clamp(32px, 6vw, 72px) clamp(20px, 7vw, 80px);
+  background: linear-gradient(160deg, #eef2ff 0%, #f8fafc 40%, #e2e8f0 100%);
   display: flex;
   justify-content: center;
+  overflow: hidden;
+}
+
+.page::before,
+.page::after {
+  content: '';
+  position: absolute;
+  width: 420px;
+  height: 420px;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.page::before {
+  top: -160px;
+  left: -120px;
+  background: rgba(99, 102, 241, 0.45);
+}
+
+.page::after {
+  right: -140px;
+  bottom: -180px;
+  background: rgba(59, 130, 246, 0.38);
 }
 
 .frame {
+  position: relative;
   width: 100%;
-  max-width: 1100px;
+  max-width: 1120px;
   display: flex;
   flex-direction: column;
-  gap: clamp(28px, 4vw, 40px);
+  gap: clamp(32px, 4vw, 44px);
 }
 
 .appBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 24px;
-  border-radius: 20px;
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
-  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.18);
+  padding: 14px 22px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.68);
+  backdrop-filter: blur(26px);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
 }
 
 .brand {
-  font-size: clamp(18px, 2.4vw, 22px);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 0;
+}
+
+.brandLogo {
+  height: auto;
+  width: clamp(112px, 14vw, 152px);
 }
 
 .appBarAction {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 18px;
+  gap: 6px;
+  padding: 8px 16px;
   border-radius: 999px;
-  background: rgba(248, 250, 252, 0.14);
-  color: inherit;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  background: rgba(255, 255, 255, 0.5);
+  color: #312e81;
   text-decoration: none;
   font-weight: 600;
-  transition: background 0.2s ease, transform 0.2s ease;
+  letter-spacing: 0.01em;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .appBarAction:hover {
-  background: rgba(248, 250, 252, 0.24);
-  transform: translateY(-1px);
+  background: rgba(99, 102, 241, 0.12);
+  color: #1e1b4b;
 }
 
 .hero {
-  background: rgba(248, 250, 252, 0.85);
-  border-radius: 28px;
+  position: relative;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(30px);
+  border-radius: 18px;
   padding: clamp(28px, 6vw, 48px);
   display: grid;
   gap: 20px;
-  box-shadow: 0 32px 60px rgba(79, 70, 229, 0.18);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 24px 42px rgba(30, 64, 175, 0.12);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  pointer-events: none;
 }
 
 .heroTitle {
   font-size: clamp(32px, 4vw, 44px);
   font-weight: 700;
-  color: #1e293b;
+  color: #0f172a;
   margin: 0;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.015em;
 }
 
 .heroDescription {
   font-size: clamp(16px, 2vw, 18px);
-  color: #475569;
+  color: #334155;
   margin: 0;
   max-width: 720px;
 }
@@ -81,62 +125,73 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 14px 26px;
+  gap: 8px;
+  padding: 12px 22px;
   border-radius: 999px;
-  background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
+  background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
   color: #fff;
   font-weight: 600;
   font-size: 16px;
   text-decoration: none;
   width: fit-content;
-  box-shadow: 0 18px 30px rgba(67, 56, 202, 0.35);
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.25);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .primaryLink:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 26px 40px rgba(67, 56, 202, 0.4);
+  transform: translateY(-1px);
+  box-shadow: 0 18px 28px rgba(79, 70, 229, 0.28);
 }
 
 .cardGrid {
   display: grid;
-  gap: clamp(20px, 3vw, 28px);
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(18px, 3vw, 28px);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .card {
-  background: rgba(248, 250, 252, 0.9);
-  border-radius: 24px;
-  padding: 24px clamp(20px, 4vw, 28px);
+  position: relative;
+  background: rgba(255, 255, 255, 0.62);
+  backdrop-filter: blur(24px);
+  border-radius: 16px;
+  padding: 22px clamp(18px, 4vw, 26px);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   border: 1px solid rgba(148, 163, 184, 0.22);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+}
+
+.card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  pointer-events: none;
 }
 
 .cardHeader {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
 .cardIcon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
-  background: rgba(99, 102, 241, 0.16);
-  font-size: 22px;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(99, 102, 241, 0.14);
+  font-size: 20px;
 }
 
 .cardTitle {
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 700;
-  color: #1f2937;
+  color: #1e293b;
   margin: 0;
 }
 
@@ -154,9 +209,9 @@
 }
 
 .chip {
-  padding: 6px 12px;
+  padding: 5px 11px;
   border-radius: 999px;
-  background: rgba(37, 99, 235, 0.14);
+  background: rgba(37, 99, 235, 0.12);
   color: #1d4ed8;
   font-size: 12px;
   font-weight: 600;
@@ -166,29 +221,30 @@
   margin-top: auto;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   color: #4338ca;
   text-decoration: none;
   font-weight: 600;
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(99, 102, 241, 0.12);
-  transition: background 0.2s ease, transform 0.2s ease;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.14);
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .cardAction:hover {
-  background: rgba(99, 102, 241, 0.2);
-  transform: translateY(-1px);
+  background: rgba(99, 102, 241, 0.22);
+  color: #312e81;
 }
 
 @media (max-width: 640px) {
   .appBar {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
+    gap: 10px;
   }
 
-  .card {
-    padding: 22px 20px;
+  .appBarAction {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/docgen-form/app/page.js
+++ b/docgen-form/app/page.js
@@ -1,4 +1,5 @@
 'use client';
+import Image from 'next/image';
 import Link from 'next/link';
 import styles from './home.module.css';
 
@@ -18,6 +19,46 @@ const CARDS = [
     description: '分步骤完成确认函填写、预览与盖章，实时生成 PDF 预览并支持自定义印章。',
     chips: ['PDF 预览', '多品牌模板', '在线盖章'],
     action: '开始预览'
+  },
+  {
+    href: '/zh-CN/custom-service-single',
+    icon: '🧭',
+    title: '咨询及委托线路定制服务单次合同',
+    description: '一次性定制线路合同模板，包含服务范围、费用条款与签署信息的完整结构。',
+    chips: ['合同生成', '服务条款', '签署指引'],
+    action: '创建合同'
+  },
+  {
+    href: '/zh-CN/custom-service-framework',
+    icon: '🗂️',
+    title: '咨询及委托线路定制服务长期框架合同',
+    description: '适用于长期合作的线路定制框架合同，支持分阶段交付与周期性结算约定。',
+    chips: ['长期合作', '周期结算', '模板分段'],
+    action: '搭建框架'
+  },
+  {
+    href: '/zh-CN/travel-handbook',
+    icon: '🧳',
+    title: '旅行出行手册',
+    description: '集合行程安排、注意事项与紧急联系方式的手册模板，随时导出分享。',
+    chips: ['行程概览', '注意事项', '联系方式'],
+    action: '整理手册'
+  },
+  {
+    href: '/zh-CN/refund-confirmation',
+    icon: '💳',
+    title: '退款信息确认函',
+    description: '快速整理退款金额、时间与方式，生成标准化的退款确认函并记录凭证。',
+    chips: ['金额确认', '凭证记录', '通知客户'],
+    action: '填写信息'
+  },
+  {
+    href: '/zh-CN/contract-supplement',
+    icon: '🧩',
+    title: '合同补充确认函',
+    description: '针对既有合同的补充说明或更新条款，一键生成带有版本记录的确认函。',
+    chips: ['补充条款', '版本记录', '签署管理'],
+    action: '新增补充'
   }
 ];
 
@@ -26,7 +67,16 @@ export default function Home() {
     <main className={styles.page}>
       <div className={styles.frame}>
         <header className={styles.appBar}>
-          <span className={styles.brand}>Vanka Docs</span>
+          <Link href="/" className={styles.brand} aria-label="Vanka 首页">
+            <Image
+              src="/branding/vanka-logo.svg"
+              alt="Vanka"
+              width={132}
+              height={28}
+              className={styles.brandLogo}
+              priority
+            />
+          </Link>
           <Link href="#templates" className={styles.appBarAction}>
             查看模板
             <span aria-hidden>↓</span>
@@ -36,7 +86,7 @@ export default function Home() {
         <section className={styles.hero}>
           <h1 className={styles.heroTitle}>一站式文档生成中心</h1>
           <p className={styles.heroDescription}>
-            遵循 Material Design 3 设计语言，帮助团队快速生成发票与预定确认函。填写表单即可实时预览，自动化输出所需文档。
+            遵循 Material Design 3 的系统规范并引入扁平磨砂的界面层次，为团队提供发票、确认函、合同与手册等多类型文档的统一生成体验。
           </p>
           <Link href="/zh-CN/invoice" className={styles.primaryLink}>
             开始创建发票


### PR DESCRIPTION
## Summary
- restyle the landing page with a flatter frosted-glass take on MD3, smaller radii, and logo support
- replace the textual brand with a linked Vanka logo slot in the app bar
- surface navigation cards for all upcoming document templates on the homepage

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cccf7285648321b3db6c8fd1f8c26a