### PR TITLE
Add placeholder pages for zh-CN template routes

### DIFF
--- a/docgen-form/app/zh-CN/contract-supplement/page.js
+++ b/docgen-form/app/zh-CN/contract-supplement/page.js
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import baseStyles from '../formStyles.module.css';
+import placeholderStyles from '../placeholder.module.css';
+
+export const metadata = {
+  title: '合同补充确认函 | Vanka 文档中心'
+};
+
+export default function ContractSupplementPage() {
+  return (
+    <div className={baseStyles.page}>
+      <div className={placeholderStyles.wrapper}>
+        <div className={baseStyles.topBar}>
+          <Link href="/" className={baseStyles.backLink}>
+            <span className={baseStyles.backIcon} aria-hidden>
+              ←
+            </span>
+            返回首页
+          </Link>
+          <span className={placeholderStyles.statusBadge}>
+            <span className={placeholderStyles.statusDot} aria-hidden />
+            建设中
+          </span>
+        </div>
+
+        <main className={placeholderStyles.main}>
+          <h1 className={baseStyles.heading}>合同补充确认函</h1>
+          <p className={placeholderStyles.description}>
+            当项目在执行过程中需要补充条款、更新价格或调整责任边界时，补充确认函可以确保信息同步且具备法律效力。我们正在优化条款模块化配置与版本留存能力。
+          </p>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>预计包含的能力</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>变更条款库：</strong> 可选择价格调整、服务扩展、时间顺延等常见条款，并支持自定义补充说明。
+              </li>
+              <li>
+                <strong>版本记录：</strong> 每次补充都会自动生成版本号和生效日期，方便追踪历史记录。
+              </li>
+              <li>
+                <strong>签署指引：</strong> 提供甲乙双方的签署位与盖章提示，可与确认函或合同一同打包导出。
+              </li>
+              <li>
+                <strong>通知留痕：</strong> 生成可发送给客户的摘要邮件或通知文案，确保双方同步。
+              </li>
+            </ul>
+          </section>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>上线前的操作建议</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>梳理原始合同：</strong> 标记需要补充或替换的条款位置，并确认是否涉及价格或付款节点的更新。
+              </li>
+              <li>
+                <strong>准备附件材料：</strong> 若涉及新增服务，请整理行程手册、报价单或确认函，方便在补充文件中引用。
+              </li>
+              <li>
+                <strong>确认审批链路：</strong> 与法务、财务或项目负责人确认审批顺序，减少补充条款往返修改的时间。
+              </li>
+            </ul>
+          </section>
+
+          <div className={placeholderStyles.supportCard}>
+            <h2 className={placeholderStyles.supportTitle}>暂时的执行方式</h2>
+            <p className={placeholderStyles.supportBody}>
+              可以在现有合同中添加补充协议附件，并借助确认函或邮件记录客户确认情况；上线后可将历史内容导入以生成标准版本。
+            </p>
+            <div className={placeholderStyles.linkRow}>
+              <Link href="/zh-CN/confirmation" className={placeholderStyles.linkButton}>
+                快速引用确认函
+                <span aria-hidden>→</span>
+              </Link>
+              <Link href="/zh-CN/custom-service-single" className={placeholderStyles.linkButton}>
+                查看合同准备事项
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
+            <p className={placeholderStyles.note}>
+              若补充条款较为复杂，建议先联系法务审核，我们也会在正式版本中提供合规校验提示。
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/docgen-form/app/zh-CN/custom-service-framework/page.js
+++ b/docgen-form/app/zh-CN/custom-service-framework/page.js
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import baseStyles from '../formStyles.module.css';
+import placeholderStyles from '../placeholder.module.css';
+
+export const metadata = {
+  title: '咨询及委托线路定制服务长期框架合同 | Vanka 文档中心'
+};
+
+export default function CustomServiceFrameworkContractPage() {
+  return (
+    <div className={baseStyles.page}>
+      <div className={placeholderStyles.wrapper}>
+        <div className={baseStyles.topBar}>
+          <Link href="/" className={baseStyles.backLink}>
+            <span className={baseStyles.backIcon} aria-hidden>
+              ←
+            </span>
+            返回首页
+          </Link>
+          <span className={placeholderStyles.statusBadge}>
+            <span className={placeholderStyles.statusDot} aria-hidden />
+            建设中
+          </span>
+        </div>
+
+        <main className={placeholderStyles.main}>
+          <h1 className={baseStyles.heading}>咨询及委托线路定制服务长期框架合同</h1>
+          <p className={placeholderStyles.description}>
+            长期合作项目通常需要更灵活的交付节奏与费用结算方式。我们正在构建支持多批次服务安排、年度指标以及对账流程的框架合同模板。
+          </p>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>计划上线的模块</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>合作范围规划：</strong> 约定年度或季度的服务目标、里程碑拆分以及双方资源投入方式。
+              </li>
+              <li>
+                <strong>费用与结算机制：</strong> 可配置包干、按单或混合结算方案，并自动同步到内部结算表与发票工具。
+              </li>
+              <li>
+                <strong>变更与追加：</strong> 预留年度额度调整、线路增补及紧急任务的快速确认流程。
+              </li>
+              <li>
+                <strong>绩效与复盘：</strong> 支持记录阶段复盘、满意度调研和续约评估，形成长期合作档案。
+              </li>
+            </ul>
+          </section>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>建议提前准备的材料</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>合作周期规划：</strong> 明确年度指标、服务频次以及是否涉及不同地区或产品线的安排。
+              </li>
+              <li>
+                <strong>财务与法务要求：</strong> 梳理结算流程、开票抬头、专票/普票需求，以及需遵循的行业合规条款。
+              </li>
+              <li>
+                <strong>协作机制：</strong> 指定双方项目负责人、例会节奏、交付验收标准和升级路径。
+              </li>
+            </ul>
+          </section>
+
+          <div className={placeholderStyles.supportCard}>
+            <h2 className={placeholderStyles.supportTitle}>在此之前的替代方案</h2>
+            <p className={placeholderStyles.supportBody}>
+              可先使用单次合同范本或内部框架协议记录合作意向，并配合确认函与手册模板同步每次具体行程。
+            </p>
+            <div className={placeholderStyles.linkRow}>
+              <Link href="/zh-CN/custom-service-single" className={placeholderStyles.linkButton}>
+                查看单次合同指引
+                <span aria-hidden>→</span>
+              </Link>
+              <Link href="/zh-CN/confirmation" className={placeholderStyles.linkButton}>
+                使用预定确认函
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
+            <p className={placeholderStyles.note}>
+              欢迎在内测登记表中补充你的框架合同需求，我们会据此安排模板设计优先级。
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/docgen-form/app/zh-CN/custom-service-single/page.js
+++ b/docgen-form/app/zh-CN/custom-service-single/page.js
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import baseStyles from '../formStyles.module.css';
+import placeholderStyles from '../placeholder.module.css';
+
+export const metadata = {
+  title: '咨询及委托线路定制服务单次合同 | Vanka 文档中心'
+};
+
+export default function CustomServiceSingleContractPage() {
+  return (
+    <div className={baseStyles.page}>
+      <div className={placeholderStyles.wrapper}>
+        <div className={baseStyles.topBar}>
+          <Link href="/" className={baseStyles.backLink}>
+            <span className={baseStyles.backIcon} aria-hidden>
+              ←
+            </span>
+            返回首页
+          </Link>
+          <span className={placeholderStyles.statusBadge}>
+            <span className={placeholderStyles.statusDot} aria-hidden />
+            建设中
+          </span>
+        </div>
+
+        <main className={placeholderStyles.main}>
+          <h1 className={baseStyles.heading}>咨询及委托线路定制服务单次合同</h1>
+          <p className={placeholderStyles.description}>
+            我们正在为一次性线路定制项目打磨结构化的合同模板，帮助团队快速说明服务范围、里程碑与费用节奏，并在生成文档时保留签署方的核心信息。
+          </p>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>即将提供的内容</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>核心条款：</strong> 规范服务范围、交付物、服务期限与质量标准，确保各方对交付边界达成一致。
+              </li>
+              <li>
+                <strong>费用与支付：</strong> 支持设定定金、阶段款和尾款等付款节点，可一键同步到确认函或发票模块。
+              </li>
+              <li>
+                <strong>双方义务：</strong> 明确委托方提供资料的时限与方式，以及服务团队的沟通、变更与保密义务。
+              </li>
+              <li>
+                <strong>违约与取消：</strong> 预置违约责任、变更处理及退款说明，方便在项目发生调整时快速引用。
+              </li>
+            </ul>
+          </section>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>上线前的准备建议</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>确认客户信息：</strong> 收集公司/个人名称、统一社会信用代码或证件信息，以及合同签署联系人。
+              </li>
+              <li>
+                <strong>整理服务需求：</strong> 归纳线路的主要站点、服务日期、包含/不包含项目，便于后续生成附件或手册。
+              </li>
+              <li>
+                <strong>规划付款节点：</strong> 提前与财务确认定金比例、到账方式与开票要求，减少合同签署后的往返沟通。
+              </li>
+            </ul>
+          </section>
+
+          <div className={placeholderStyles.supportCard}>
+            <h2 className={placeholderStyles.supportTitle}>现在可以怎么做？</h2>
+            <p className={placeholderStyles.supportBody}>
+              在模板发布之前，可使用确认函与发票工具记录项目基础信息，并将整理好的需求文档附加到现有合同范本中。
+            </p>
+            <div className={placeholderStyles.linkRow}>
+              <Link href="/zh-CN/confirmation" className={placeholderStyles.linkButton}>
+                前往预定信息确认函
+                <span aria-hidden>→</span>
+              </Link>
+              <Link href="/zh-CN/invoice" className={placeholderStyles.linkButton}>
+                快速生成发票
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
+            <p className={placeholderStyles.note}>
+              需要优先体验该合同？请在团队协作平台反馈需求，产品团队会第一时间同步进度。
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/docgen-form/app/zh-CN/placeholder.module.css
+++ b/docgen-form/app/zh-CN/placeholder.module.css
@@ -1,0 +1,139 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 3vw, 32px);
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 3vw, 32px);
+}
+
+.description {
+  font-size: clamp(16px, 2vw, 18px);
+  line-height: 1.7;
+  color: #475569;
+  margin: 0;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.14);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.section {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 20px;
+  padding: clamp(20px, 4vw, 32px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: clamp(18px, 2.3vw, 22px);
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 12px;
+  color: #334155;
+  font-size: 15px;
+  line-height: 1.65;
+}
+
+.list strong {
+  color: #0f172a;
+}
+
+.supportCard {
+  background: rgba(59, 130, 246, 0.1);
+  border-radius: 18px;
+  padding: clamp(20px, 4vw, 28px);
+  border: 1px dashed rgba(37, 99, 235, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.supportTitle {
+  margin: 0;
+  font-size: clamp(17px, 2vw, 20px);
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.supportBody {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.7;
+  color: #1e293b;
+}
+
+.linkRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.linkButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #1d4ed8;
+  background: #ffffff;
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.linkButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.22);
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.linkButton span[aria-hidden='true'] {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.note {
+  margin: 0;
+  font-size: 14px;
+  color: #64748b;
+  line-height: 1.6;
+}

--- a/docgen-form/app/zh-CN/refund-confirmation/page.js
+++ b/docgen-form/app/zh-CN/refund-confirmation/page.js
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import baseStyles from '../formStyles.module.css';
+import placeholderStyles from '../placeholder.module.css';
+
+export const metadata = {
+  title: '退款信息确认函 | Vanka 文档中心'
+};
+
+export default function RefundConfirmationPage() {
+  return (
+    <div className={baseStyles.page}>
+      <div className={placeholderStyles.wrapper}>
+        <div className={baseStyles.topBar}>
+          <Link href="/" className={baseStyles.backLink}>
+            <span className={baseStyles.backIcon} aria-hidden>
+              ←
+            </span>
+            返回首页
+          </Link>
+          <span className={placeholderStyles.statusBadge}>
+            <span className={placeholderStyles.statusDot} aria-hidden />
+            建设中
+          </span>
+        </div>
+
+        <main className={placeholderStyles.main}>
+          <h1 className={baseStyles.heading}>退款信息确认函</h1>
+          <p className={placeholderStyles.description}>
+            退款确认函将用于向客户说明退款原因、金额、到账时间以及付款渠道，便于双方留存凭证并追踪后续进度。目前页面正在完善导出格式与审批流程。
+          </p>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>模板重点规划</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>退款概览：</strong> 包含原订单信息、退款项目、币种和对应金额，支持自动换算多币种成本。
+              </li>
+              <li>
+                <strong>到账安排：</strong> 记录退款账户、到账渠道、预计到账日期及跟进联系人。
+              </li>
+              <li>
+                <strong>附件说明：</strong> 可附上客户确认截图、银行水单或内部审批记录，确保审计留痕。
+              </li>
+              <li>
+                <strong>审批签署：</strong> 支持财务与业务负责人电子签名，并同步到内部退款台账。
+              </li>
+            </ul>
+          </section>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>在模板上线前的建议流程</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>整理退款依据：</strong> 通过确认函或合同补充记录退款触发条件，方便在文档中引用原始约定。
+              </li>
+              <li>
+                <strong>同步财务状态：</strong> 与财务确认退款路径、收款人姓名及银行卡/支付宝等关键信息。
+              </li>
+              <li>
+                <strong>留存沟通记录：</strong> 将客户确认邮件或聊天截图整理到共享空间，后续可以直接插入模板附件区。
+              </li>
+            </ul>
+          </section>
+
+          <div className={placeholderStyles.supportCard}>
+            <h2 className={placeholderStyles.supportTitle}>当前可用工具</h2>
+            <p className={placeholderStyles.supportBody}>
+              建议先用预定确认函说明调整内容，随后在发票模块补充负数行或备注退款信息，等待正式模板上线后再输出标准文档。
+            </p>
+            <div className={placeholderStyles.linkRow}>
+              <Link href="/zh-CN/confirmation" className={placeholderStyles.linkButton}>
+                查看预定确认函
+                <span aria-hidden>→</span>
+              </Link>
+              <Link href="/zh-CN/invoice" className={placeholderStyles.linkButton}>
+                更新发票/对账
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
+            <p className={placeholderStyles.note}>
+              如需加急开通退款模板，请提交业务场景和预计使用时间，我们会主动联系支持。
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/docgen-form/app/zh-CN/travel-handbook/page.js
+++ b/docgen-form/app/zh-CN/travel-handbook/page.js
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import baseStyles from '../formStyles.module.css';
+import placeholderStyles from '../placeholder.module.css';
+
+export const metadata = {
+  title: '旅行出行手册 | Vanka 文档中心'
+};
+
+export default function TravelHandbookPage() {
+  return (
+    <div className={baseStyles.page}>
+      <div className={placeholderStyles.wrapper}>
+        <div className={baseStyles.topBar}>
+          <Link href="/" className={baseStyles.backLink}>
+            <span className={baseStyles.backIcon} aria-hidden>
+              ←
+            </span>
+            返回首页
+          </Link>
+          <span className={placeholderStyles.statusBadge}>
+            <span className={placeholderStyles.statusDot} aria-hidden />
+            建设中
+          </span>
+        </div>
+
+        <main className={placeholderStyles.main}>
+          <h1 className={baseStyles.heading}>旅行出行手册</h1>
+          <p className={placeholderStyles.description}>
+            出行手册会汇总完整的行程安排、携带建议和紧急联系方式，帮助客户在出发前获取所有关键信息。模板正在设计中，我们会在发布后提供多语言导出能力。
+          </p>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>手册将包含</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>日程总览：</strong> 每日行程亮点、交通与集合信息，以及可选体验的提醒。
+              </li>
+              <li>
+                <strong>准备事项：</strong> 打包建议、天气提示、签证/保险状态与注意事项清单。
+              </li>
+              <li>
+                <strong>服务说明：</strong> 领队与当地伙伴联系方式、应急流程以及服务范围界定。
+              </li>
+              <li>
+                <strong>附录资源：</strong> 可插入电子票、地图链接、常用语对照表等附件，便于客户随时查阅。
+              </li>
+            </ul>
+          </section>
+
+          <section className={placeholderStyles.section}>
+            <h2 className={placeholderStyles.sectionTitle}>现在可以提前准备</h2>
+            <ul className={placeholderStyles.list}>
+              <li>
+                <strong>整理行程表：</strong> 将每日时间表和活动安排录入到确认函或项目管理工具，后续可一键导入手册。
+              </li>
+              <li>
+                <strong>收集联系方式：</strong> 维护领队、紧急联系人和目的地服务商的通讯方式，确保手册信息准确。
+              </li>
+              <li>
+                <strong>沉淀素材：</strong> 准备目的地图片、餐饮及文化亮点介绍，发布时即可在手册中展示品牌调性。
+              </li>
+            </ul>
+          </section>
+
+          <div className={placeholderStyles.supportCard}>
+            <h2 className={placeholderStyles.supportTitle}>临时解决方案</h2>
+            <p className={placeholderStyles.supportBody}>
+              可将确认函导出的 PDF 作为基础信息，同时附加自定义的行前提醒文档，或在内部知识库维护最新的出行说明链接。
+            </p>
+            <div className={placeholderStyles.linkRow}>
+              <Link href="/zh-CN/confirmation" className={placeholderStyles.linkButton}>
+                使用预定确认函
+                <span aria-hidden>→</span>
+              </Link>
+              <Link href="/zh-CN/invoice" className={placeholderStyles.linkButton}>
+                管理关联订单
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
+            <p className={placeholderStyles.note}>
+              若你已有手册范本，欢迎反馈给产品团队，我们会在上线版本中提供导入支持。
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder styling module for zh-CN informational pages
- create landing pages for the custom service, refund, handbook, and supplement routes with clear guidance
- link users back to available tools while templates are under construction

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd496e4c4832186c93c726bbfb39d