### PR TITLE
Refine Morandi theming across home and invoice pages

### DIFF
--- a/docgen-form/app/home.module.css
+++ b/docgen-form/app/home.module.css
@@ -3,10 +3,10 @@
   min-height: 100vh;
   padding: clamp(32px, 6vw, 72px) clamp(20px, 7vw, 80px);
   background:
-    radial-gradient(120% 120% at 8% 12%, rgba(59, 130, 246, 0.22), transparent 60%),
-    radial-gradient(120% 120% at 88% 14%, rgba(129, 140, 248, 0.18), transparent 64%),
-    radial-gradient(130% 120% at 50% 92%, rgba(165, 180, 252, 0.18), transparent 70%),
-    linear-gradient(160deg, #eef2ff 0%, #f8fafc 40%, #e2e8f0 100%);
+    radial-gradient(145% 135% at 14% 18%, rgba(209, 214, 216, 0.55), transparent 68%),
+    radial-gradient(120% 130% at 86% 14%, rgba(204, 198, 205, 0.48), transparent 70%),
+    radial-gradient(130% 150% at 50% 84%, rgba(190, 202, 198, 0.5), transparent 74%),
+    linear-gradient(188deg, #bcc4cb 0%, #cfc7c2 48%, #c5d2cb 100%);
   display: flex;
   justify-content: center;
   overflow: hidden;
@@ -16,28 +16,28 @@
 .page::after {
   content: '';
   position: absolute;
-  width: 420px;
-  height: 420px;
-  border-radius: 50%;
-  filter: blur(120px);
-  opacity: 0.55;
+  inset: -35% -20% -20% -20%;
+  border-radius: 40% 60% 52% 48% / 38% 50% 50% 62%;
+  filter: blur(80px);
+  opacity: 0.6;
   pointer-events: none;
   mix-blend-mode: screen;
-  animation: driftBackdrop 38s ease-in-out infinite
+  background-size: 220% 220%;
+  animation: auroraWave 36s ease-in-out infinite, driftBackdrop 46s ease-in-out infinite;
 }
 
 .page::before {
-  top: -160px;
-  left: -120px;
-  background: rgba(99, 102, 241, 0.45);
-  animation-delay: -12s;
+  background:
+    radial-gradient(145% 125% at 16% 32%, rgba(233, 230, 224, 0.38), transparent 72%),
+    linear-gradient(118deg, rgba(176, 183, 189, 0.5) 0%, rgba(167, 176, 183, 0.38) 46%, rgba(204, 196, 198, 0.42) 100%);
+  animation-delay: -14s;
 }
 
 .page::after {
-  right: -140px;
-  bottom: -180px;
-  background: rgba(59, 130, 246, 0.38);
-  animation-delay: -22s;
+  background:
+    radial-gradient(150% 120% at 82% 68%, rgba(214, 202, 204, 0.34), transparent 68%),
+    linear-gradient(140deg, rgba(165, 176, 182, 0.38) 0%, rgba(154, 168, 175, 0.32) 38%, rgba(204, 196, 198, 0.38) 100%);
+  animation-delay: -26s;
 }
 
 .ambientBackdrop {
@@ -52,10 +52,12 @@
   content: '';
   position: absolute;
   inset: -30% -10% 12% -10%;
-  background: linear-gradient(125deg, rgba(255, 255, 255, 0.08), rgba(148, 163, 184, 0.06));
-  filter: blur(60px);
+  background:
+    linear-gradient(130deg, rgba(195, 200, 204, 0.2) 0%, rgba(167, 177, 182, 0.28) 42%, rgba(204, 195, 196, 0.24) 78%, rgba(174, 185, 184, 0.28) 100%);
+  background-size: 200% 200%;
+  filter: blur(70px);
   opacity: 0.55;
-  animation: liquidWaves 42s ease-in-out infinite;
+  animation: auroraWave 40s ease-in-out infinite, liquidWaves 42s ease-in-out infinite;
 }
 
 .ambientOrb {
@@ -63,9 +65,9 @@
   border-radius: 50%;
   filter: blur(0.5px);
   mix-blend-mode: screen;
-  opacity: 0.75;
+  opacity: 0.65;
   animation: floatOrb 18s ease-in-out infinite;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(129, 140, 248, 0.1) 65%);
+  background: radial-gradient(circle at 30% 30%, rgba(237, 234, 228, 0.85), rgba(156, 164, 169, 0.16) 70%);
 }
 
 .orbPrimary {
@@ -82,7 +84,7 @@
   top: 58%;
   right: 12%;
   animation-duration: 22s;
-  background: radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.85), rgba(96, 165, 250, 0.18) 60%);
+  background: radial-gradient(circle at 70% 30%, rgba(221, 217, 214, 0.78), rgba(146, 156, 162, 0.18) 64%);
 }
 
 .orbTertiary {
@@ -92,7 +94,7 @@
   left: 22%;
   animation-delay: -8s;
   animation-duration: 26s;
-  background: radial-gradient(circle at 30% 70%, rgba(244, 114, 182, 0.35), rgba(129, 140, 248, 0.06) 70%);
+  background: radial-gradient(circle at 30% 70%, rgba(212, 199, 201, 0.46), rgba(157, 149, 158, 0.1) 72%);
 }
 
 .liquidGlass {
@@ -101,9 +103,9 @@
   height: clamp(320px, 36vw, 520px);
   border-radius: 42% 58% 45% 55% / 45% 46% 54% 55%;
   background:
-    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.52), transparent 70%),
-    radial-gradient(circle at 70% 70%, rgba(129, 140, 248, 0.32), rgba(30, 64, 175, 0.1));
-  opacity: 0.4;
+    radial-gradient(circle at 30% 30%, rgba(240, 236, 230, 0.52), transparent 72%),
+    radial-gradient(circle at 70% 70%, rgba(174, 182, 189, 0.3), rgba(128, 138, 146, 0.12));
+  opacity: 0.46;
   filter: saturate(115%);
   mix-blend-mode: screen;
   animation: liquidMorph 48s ease-in-out infinite;
@@ -127,9 +129,9 @@
   width: clamp(220px, 28vw, 360px);
   height: clamp(420px, 48vw, 620px);
   border-radius: 999px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(236, 72, 153, 0.18) 35%, rgba(14, 165, 233, 0.12));
+  background: linear-gradient(185deg, rgba(255, 255, 255, 0) 0%, rgba(204, 197, 195, 0.24) 38%, rgba(163, 174, 182, 0.18) 100%);
   filter: blur(1px);
-  opacity: 0.45;
+  opacity: 0.5;
   mix-blend-mode: screen;
   transform: rotate(-12deg);
   animation: beamSweep 30s ease-in-out infinite;
@@ -192,81 +194,10 @@
   width: 360px;
   height: 160px;
   border-radius: 999px;
-  background: linear-gradient(115deg, rgba(255, 255, 255, 0.28) 10%, rgba(255, 255, 255, 0.02) 70%);
+  background: linear-gradient(115deg, rgba(227, 223, 219, 0.32) 10%, rgba(227, 223, 219, 0.04) 70%);
   filter: blur(0.4px);
   mix-blend-mode: lighten;
-  opacity: 0.55;
-  --streak-rotation: 14deg;
-  animation: driftStreak 26s ease-in-out infinite;
-}
-
-.streakOne {
-  top: 24%;
-  right: -80px;
-  --streak-rotation: 18deg;
-}
-
-.streakTwo {
-  bottom: -40px;
-  left: -120px;
-  animation-delay: -10s;
-  --streak-rotation: -18deg;
-}
-
-.ambientBackdrop {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: 0;
-}
-
-.ambientOrb {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(0.5px);
-  mix-blend-mode: screen;
-  opacity: 0.75;
-  animation: floatOrb 18s ease-in-out infinite;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(129, 140, 248, 0.1) 65%);
-}
-
-.orbPrimary {
-  width: 320px;
-  height: 320px;
-  top: 12%;
-  left: 8%;
-  animation-delay: -2s;
-}
-
-.orbSecondary {
-  width: 220px;
-  height: 220px;
-  top: 58%;
-  right: 12%;
-  animation-duration: 22s;
-  background: radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.85), rgba(96, 165, 250, 0.18) 60%);
-}
-
-.orbTertiary {
-  width: 180px;
-  height: 180px;
-  top: 72%;
-  left: 22%;
-  animation-delay: -8s;
-  animation-duration: 26s;
-  background: radial-gradient(circle at 30% 70%, rgba(244, 114, 182, 0.35), rgba(129, 140, 248, 0.06) 70%);
-}
-
-.glassStreak {
-  position: absolute;
-  width: 360px;
-  height: 160px;
-  border-radius: 999px;
-  background: linear-gradient(115deg, rgba(255, 255, 255, 0.28) 10%, rgba(255, 255, 255, 0.02) 70%);
-  filter: blur(0.4px);
-  mix-blend-mode: lighten;
-  opacity: 0.55;
+  opacity: 0.6;
   --streak-rotation: 14deg;
   animation: driftStreak 26s ease-in-out infinite;
 }
@@ -301,10 +232,11 @@
   padding: 14px 22px;
   border-radius: 14px;
   position: relative;
-  background: rgba(255, 255, 255, 0.68);
+  background: linear-gradient(135deg, rgba(246, 244, 240, 0.82), rgba(228, 232, 235, 0.76));
+  color: #2c3037;
   backdrop-filter: blur(26px);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(177, 186, 193, 0.38);
+  box-shadow: 0 20px 38px rgba(142, 149, 157, 0.28);
   overflow: hidden;
   transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -313,10 +245,10 @@
   content: '';
   position: absolute;
   inset: -40% -20%;
-  background: conic-gradient(from 120deg, rgba(79, 70, 229, 0.18), rgba(129, 140, 248, 0.04), rgba(14, 116, 144, 0.12), rgba(79, 70, 229, 0.18));
-  filter: blur(42px);
+  background: conic-gradient(from 120deg, rgba(207, 202, 196, 0.35), rgba(178, 188, 195, 0.24), rgba(214, 206, 206, 0.32), rgba(188, 199, 202, 0.3));
+  filter: blur(52px);
   transform: rotate(8deg);
-  animation: rotateGlow 28s linear infinite;
+  animation: rotateGlow 32s linear infinite;
   pointer-events: none;
 }
 
@@ -325,12 +257,12 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.26);
   pointer-events: none;
 }
 .appBar:hover {
   transform: translateY(-3px) scale(1.01);
-  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 28px 46px rgba(142, 149, 157, 0.32);
 }
 
 .brand {
@@ -354,9 +286,9 @@
   gap: 6px;
   padding: 8px 16px;
   border-radius: 999px;
-  border: 1px solid rgba(99, 102, 241, 0.35);
-  background: rgba(255, 255, 255, 0.5);
-  color: #312e81;
+  border: 1px solid rgba(177, 186, 193, 0.36);
+  background: rgba(209, 206, 202, 0.32);
+  color: #2f3338;
   text-decoration: none;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -364,22 +296,23 @@
 }
 
 .appBarAction:hover {
-  background: rgba(99, 102, 241, 0.12);
-  color: #1e1b4b;
+  background: rgba(209, 206, 202, 0.46);
+  color: #1f242a;
   transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.18);
+  box-shadow: 0 16px 30px rgba(140, 147, 154, 0.26);
 }
 
 .hero {
   position: relative;
-  background: rgba(255, 255, 255, 0.7);
+  background: linear-gradient(150deg, rgba(245, 242, 238, 0.88), rgba(224, 229, 232, 0.78));
   backdrop-filter: blur(30px);
   border-radius: 18px;
   padding: clamp(28px, 6vw, 48px);
   display: grid;
   gap: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  box-shadow: 0 24px 42px rgba(30, 64, 175, 0.12);
+  color: #2c3037;
+  border: 1px solid rgba(186, 194, 200, 0.38);
+  box-shadow: 0 28px 46px rgba(153, 160, 166, 0.28);
   overflow: hidden;
   transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -387,12 +320,12 @@
 .hero::before {
   content: '';
   position: absolute;
-  inset: 8px;
+  inset: 10px;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.24), rgba(14, 165, 233, 0.16));
-  opacity: 0.35;
-  filter: blur(18px);
-  animation: pulseGlow 5s ease-in-out infinite;
+  background: linear-gradient(135deg, rgba(211, 207, 204, 0.4), rgba(192, 200, 203, 0.24));
+  opacity: 0.32;
+  filter: blur(22px);
+  animation: pulseGlow 6s ease-in-out infinite;
   pointer-events: none;
 }
 
@@ -401,26 +334,26 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.28);
   pointer-events: none;
 }
 
 .hero:hover {
   transform: translateY(-5px) scale(1.01);
-  box-shadow: 0 28px 46px rgba(30, 64, 175, 0.18);
+  box-shadow: 0 34px 58px rgba(153, 160, 166, 0.32);
 }
 
 .heroTitle {
   font-size: clamp(32px, 4vw, 44px);
   font-weight: 700;
-  color: #0f172a;
+  color: #2a3035;
   margin: 0;
   letter-spacing: -0.015em;
 }
 
 .heroDescription {
   font-size: clamp(16px, 2vw, 18px);
-  color: #334155;
+  color: #5d6369;
   margin: 0;
   max-width: 720px;
 }
@@ -432,13 +365,13 @@
   gap: 8px;
   padding: 12px 22px;
   border-radius: 999px;
-  background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
-  color: #fff;
+  background: linear-gradient(135deg, #a6b0ae 0%, #c1b4b0 100%);
+  color: #262d32;
   font-weight: 600;
   font-size: 16px;
   text-decoration: none;
   width: fit-content;
-  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.25);
+  box-shadow: 0 16px 28px rgba(137, 146, 151, 0.32);
   transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.45s cubic-bezier(0.22, 1, 0.36, 1);
   position: relative;
   overflow: hidden;
@@ -446,29 +379,14 @@
 
 .primaryLink:hover {
   transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 20px 34px rgba(79, 70, 229, 0.32);
+  box-shadow: 0 22px 36px rgba(137, 146, 151, 0.38);
 }
 
 .primaryLink::after {
   content: '';
   position: absolute;
   inset: -40% -20%;
-  background: radial-gradient(circle at 30% 50%, rgba(255, 255, 255, 0.6), transparent 50%);
-  opacity: 0;
-  transform: translate3d(-20%, 0, 0);
-  transition: opacity 0.25s ease, transform 0.25s ease;
-}
-
-.primaryLink:hover::after {
-  opacity: 1;
-  transform: translate3d(35%, 0, 0);
-}
-
-.primaryLink::after {
-  content: '';
-  position: absolute;
-  inset: -40% -20%;
-  background: radial-gradient(circle at 30% 50%, rgba(255, 255, 255, 0.6), transparent 50%);
+  background: radial-gradient(circle at 30% 50%, rgba(255, 255, 255, 0.72), transparent 50%);
   opacity: 0;
   transform: translate3d(-20%, 0, 0);
   transition: opacity 0.25s ease, transform 0.25s ease;
@@ -487,15 +405,16 @@
 
 .card {
   position: relative;
-  background: rgba(255, 255, 255, 0.62);
+  background: linear-gradient(160deg, rgba(248, 246, 242, 0.9), rgba(232, 236, 236, 0.82));
   backdrop-filter: blur(24px);
   border-radius: 16px;
   padding: 22px clamp(18px, 4vw, 26px);
   display: flex;
   flex-direction: column;
   gap: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+  color: #2f3338;
+  border: 1px solid rgba(190, 198, 202, 0.38);
+  box-shadow: 0 24px 42px rgba(156, 162, 166, 0.26);
   transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.6s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.4s ease;
   overflow: hidden;
 }
@@ -505,7 +424,7 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   pointer-events: none;
 }
 
@@ -513,8 +432,8 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 120% -20%, rgba(96, 165, 250, 0.22), transparent 55%),
-    radial-gradient(circle at -10% 120%, rgba(244, 114, 182, 0.16), transparent 60%);
+  background: radial-gradient(circle at 120% -20%, rgba(205, 200, 197, 0.32), transparent 58%),
+    radial-gradient(circle at -10% 120%, rgba(198, 206, 206, 0.28), transparent 62%);
   opacity: 0;
   transition: opacity 0.35s ease;
   pointer-events: none;
@@ -522,8 +441,8 @@
 
 .card:hover {
   transform: translateY(-10px) scale(1.02);
-  box-shadow: 0 26px 44px rgba(30, 64, 175, 0.2);
-  border-color: rgba(99, 102, 241, 0.32);
+  box-shadow: 0 32px 52px rgba(153, 160, 166, 0.34);
+  border-color: rgba(184, 194, 200, 0.46);
 }
 
 .card:hover::before {
@@ -543,20 +462,20 @@
   width: 40px;
   height: 40px;
   border-radius: 12px;
-  background: rgba(99, 102, 241, 0.14);
+  background: rgba(206, 206, 203, 0.45);
   font-size: 20px;
 }
 
 .cardTitle {
   font-size: 18px;
   font-weight: 700;
-  color: #1e293b;
+  color: #2b3036;
   margin: 0;
 }
 
 .cardDescription {
   font-size: 14px;
-  color: #475569;
+  color: #5e656c;
   line-height: 1.6;
   margin: 0;
 }
@@ -570,12 +489,12 @@
 .chip {
   padding: 5px 11px;
   border-radius: 999px;
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
+  background: rgba(207, 204, 200, 0.38);
+  color: #2f343a;
   font-size: 12px;
   font-weight: 600;
   backdrop-filter: blur(6px);
-  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(187, 194, 198, 0.42);
 }
 
 .cardAction {
@@ -583,20 +502,39 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: #4338ca;
+  color: #2f3338;
   text-decoration: none;
   font-weight: 600;
   padding: 10px 12px;
   border-radius: 999px;
-  background: rgba(99, 102, 241, 0.14);
+  background: rgba(207, 203, 199, 0.36);
   transition: transform 0.35s ease, background 0.25s ease, color 0.25s ease;
-  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(187, 194, 198, 0.4);
 }
 
 .cardAction:hover {
-  background: rgba(99, 102, 241, 0.22);
-  color: #312e81;
-  transform: translateX(2px) scale(1.01);
+  background: rgba(207, 203, 199, 0.48);
+  color: #1f252b;
+  transform: translateX(2px) scale(1.02);
+}
+
+@keyframes auroraWave {
+  0% {
+    background-position: 0% 50%;
+    opacity: 0.45;
+  }
+  40% {
+    background-position: 45% 60%;
+    opacity: 0.62;
+  }
+  70% {
+    background-position: 100% 42%;
+    opacity: 0.5;
+  }
+  100% {
+    background-position: 0% 50%;
+    opacity: 0.45;
+  }
 }
 
 @keyframes floatOrb {

--- a/docgen-form/app/zh-CN/formStyles.module.css
+++ b/docgen-form/app/zh-CN/formStyles.module.css
@@ -1,8 +1,8 @@
 .page {
   padding: clamp(32px, 4vw, 48px) clamp(24px, 6vw, 96px) 56px;
-  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+  background: linear-gradient(140deg, #cbd2d0 0%, #d9d2ce 46%, #c9d5d2 100%);
   min-height: 100%;
-  color: #0f172a;
+  color: #2c3238;
 }
 
 .topBar {
@@ -22,17 +22,17 @@
   border-radius: 999px;
   font-size: 14px;
   font-weight: 600;
-  color: #1d4ed8;
+  color: #2f353a;
   text-decoration: none;
-  background: rgba(37, 99, 235, 0.12);
-  box-shadow: 0 1px 0 rgba(37, 99, 235, 0.08);
+  background: rgba(204, 204, 200, 0.4);
+  box-shadow: 0 1px 0 rgba(161, 170, 172, 0.25);
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .backLink:hover {
-  background: rgba(37, 99, 235, 0.18);
+  background: rgba(204, 204, 200, 0.52);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
+  box-shadow: 0 6px 16px rgba(148, 156, 160, 0.28);
 }
 
 .backIcon {
@@ -68,11 +68,11 @@
 }
 
 .card {
-  background: rgba(255, 255, 255, 0.95);
+  background: linear-gradient(155deg, rgba(247, 244, 240, 0.9), rgba(229, 233, 233, 0.82));
   border-radius: 20px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  backdrop-filter: blur(6px);
+  box-shadow: 0 24px 48px rgba(143, 151, 155, 0.18);
+  border: 1px solid rgba(184, 192, 196, 0.32);
+  backdrop-filter: blur(10px);
 }
 
 .formCard {
@@ -101,12 +101,12 @@
   font-size: clamp(18px, 2vw, 22px);
   font-weight: 600;
   margin: 0;
-  color: #1e293b;
+  color: #32383e;
 }
 
 .sectionHint {
   font-size: 14px;
-  color: #64748b;
+  color: #6e767b;
   margin: 0;
 }
 
@@ -124,18 +124,18 @@
 .fieldLabel {
   font-size: 14px;
   font-weight: 500;
-  color: #1f2937;
+  color: #363c41;
 }
 
 .fieldHint {
   font-size: 12px;
-  color: #64748b;
+  color: #737b81;
 }
 
 .textControl {
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background: rgba(248, 250, 252, 0.8);
+  border: 1px solid rgba(171, 182, 186, 0.52);
+  background: rgba(239, 238, 235, 0.76);
   padding: 12px 14px;
   font-size: 15px;
   line-height: 1.5;
@@ -145,13 +145,13 @@
 
 .textControl:focus {
   outline: none;
-  border-color: #6366f1;
-  background: #fff;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+  border-color: #9aa6a3;
+  background: rgba(249, 248, 245, 0.95);
+  box-shadow: 0 0 0 3px rgba(154, 166, 163, 0.28);
 }
 
 .textControl::placeholder {
-  color: #94a3b8;
+  color: #8c9498;
 }
 
 .buttonRow {
@@ -166,31 +166,31 @@
   padding: 12px 24px;
   font-size: 15px;
   font-weight: 600;
-  color: #fff;
-  background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
-  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.3);
+  color: #252b30;
+  background: linear-gradient(135deg, #a0aba8 0%, #c0b0ac 100%);
+  box-shadow: 0 14px 26px rgba(151, 158, 160, 0.28);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .primaryButton:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;
 }
 
 .primaryButton:not(:disabled):hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 32px rgba(67, 56, 202, 0.35);
+  box-shadow: 0 18px 32px rgba(151, 158, 160, 0.36);
 }
 
 .secondaryButton {
   align-self: flex-start;
   padding: 10px 18px;
   border-radius: 999px;
-  border: 1px dashed rgba(99, 102, 241, 0.5);
-  background: rgba(99, 102, 241, 0.08);
-  color: #4338ca;
+  border: 1px dashed rgba(164, 172, 176, 0.6);
+  background: rgba(204, 202, 198, 0.32);
+  color: #2f3439;
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -198,8 +198,8 @@
 }
 
 .secondaryButton:hover {
-  background: rgba(99, 102, 241, 0.16);
-  border-color: rgba(67, 56, 202, 0.7);
+  background: rgba(204, 202, 198, 0.44);
+  border-color: rgba(164, 172, 176, 0.8);
   transform: translateY(-1px);
 }
 
@@ -207,7 +207,7 @@
   appearance: none;
   border: none;
   background: transparent;
-  color: #ef4444;
+  color: #b96464;
   font-size: 13px;
   font-weight: 600;
   padding: 6px 10px;
@@ -217,8 +217,8 @@
 }
 
 .ghostButton:hover {
-  background: rgba(239, 68, 68, 0.12);
-  color: #b91c1c;
+  background: rgba(185, 100, 100, 0.14);
+  color: #944d4d;
 }
 
 .previewGroup {
@@ -236,7 +236,7 @@
 .previewSectionTitle {
   font-size: 15px;
   font-weight: 600;
-  color: #475569;
+  color: #555c62;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin: 0;
@@ -249,21 +249,21 @@
   align-items: flex-start;
   padding: 10px 12px;
   border-radius: 12px;
-  background: rgba(248, 250, 252, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(243, 241, 236, 0.88);
+  border: 1px solid rgba(187, 195, 198, 0.34);
 }
 
 .previewLabel {
   font-size: 13px;
   font-weight: 500;
-  color: #64748b;
+  color: #6d7479;
   width: 120px;
   flex-shrink: 0;
 }
 
 .previewValue {
   font-size: 14px;
-  color: #1f2937;
+  color: #31373d;
   white-space: pre-wrap;
   word-break: break-word;
   flex: 1;
@@ -277,8 +277,8 @@
 
 .selectControl {
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background: rgba(248, 250, 252, 0.8);
+  border: 1px solid rgba(171, 182, 186, 0.52);
+  background: rgba(239, 238, 235, 0.76);
   padding: 10px 14px;
   font-size: 14px;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -286,28 +286,28 @@
 
 .selectControl:focus {
   outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
-  background: #fff;
+  border-color: #9aa6a3;
+  box-shadow: 0 0 0 3px rgba(154, 166, 163, 0.28);
+  background: rgba(249, 248, 245, 0.95);
 }
 
 .errorBanner {
   margin-top: 16px;
   padding: 12px 16px;
   border-radius: 12px;
-  background: rgba(248, 113, 113, 0.15);
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  color: #b91c1c;
+  background: rgba(199, 118, 118, 0.18);
+  border: 1px solid rgba(176, 92, 92, 0.32);
+  color: #8f3f3f;
 }
 
 .pdfPreview {
   margin-top: 32px;
   position: relative;
   border-radius: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(226, 232, 240, 0.55);
+  border: 1px solid rgba(188, 196, 198, 0.36);
+  background: rgba(232, 236, 236, 0.62);
   padding: 16px;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(188, 196, 198, 0.2);
 }
 
 .pdfPage {
@@ -316,7 +316,7 @@
   height: auto;
   margin-bottom: 16px;
   border-radius: 12px;
-  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 20px 30px rgba(136, 143, 146, 0.22);
 }
 
 .stamp {
@@ -334,7 +334,7 @@
 
 .emptyPreviewHint {
   font-size: 14px;
-  color: #94a3b8;
+  color: #7d868c;
   margin: 0;
 }
 
@@ -350,29 +350,29 @@
   gap: 6px;
   padding: 8px 14px;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background: rgba(248, 250, 252, 0.85);
+  border: 1px solid rgba(171, 182, 186, 0.52);
+  background: rgba(239, 238, 235, 0.76);
   cursor: pointer;
   transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .radioOption[data-selected='true'] {
-  border-color: #6366f1;
-  background: rgba(99, 102, 241, 0.12);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.12);
+  border-color: #9aa6a3;
+  background: rgba(154, 166, 163, 0.26);
+  box-shadow: 0 0 0 2px rgba(154, 166, 163, 0.18);
 }
 
 .radioOption input {
   margin: 0;
-  accent-color: #6366f1;
+  accent-color: #9aa6a3;
 }
 
 .detailList {
   margin: 18px 0 0;
   padding: 18px;
   border-radius: 16px;
-  background: rgba(226, 232, 240, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(236, 234, 229, 0.52);
+  border: 1px solid rgba(187, 195, 198, 0.34);
   display: grid;
   gap: 12px;
 }
@@ -386,13 +386,13 @@
 .detailTerm {
   font-size: 13px;
   font-weight: 600;
-  color: #475569;
+  color: #6d7379;
   min-width: 96px;
 }
 
 .detailValue {
   font-size: 14px;
-  color: #1f2937;
+  color: #31373d;
   flex: 1;
   white-space: pre-wrap;
   word-break: break-word;
@@ -409,8 +409,8 @@
   gap: 16px;
   padding: 18px;
   border-radius: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(248, 250, 252, 0.7);
+  border: 1px solid rgba(187, 195, 198, 0.34);
+  background: rgba(237, 235, 230, 0.62);
 }
 
 .projectTitleInput {
@@ -432,12 +432,12 @@
 .priceItemCard {
   padding: 20px;
   border-radius: 18px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(248, 250, 252, 0.85);
+  border: 1px solid rgba(187, 195, 198, 0.34);
+  background: rgba(238, 236, 232, 0.72);
   display: flex;
   flex-direction: column;
   gap: 18px;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+  box-shadow: 0 12px 28px rgba(150, 157, 160, 0.18);
 }
 
 .priceItemHeader {
@@ -450,7 +450,7 @@
 .priceItemTitle {
   font-size: 15px;
   font-weight: 600;
-  color: #1f2937;
+  color: #32383e;
 }
 
 .priceItemActions {
@@ -483,8 +483,8 @@
 
 .previewPriceItem {
   border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(248, 250, 252, 0.85);
+  border: 1px solid rgba(187, 195, 198, 0.34);
+  background: rgba(238, 236, 232, 0.72);
   padding: 12px 14px;
   display: flex;
   flex-direction: column;
@@ -501,13 +501,13 @@
 .previewPriceName {
   font-size: 14px;
   font-weight: 600;
-  color: #1f2937;
+  color: #32383e;
 }
 
 .previewPriceAmount {
   font-size: 14px;
   font-weight: 600;
-  color: #4338ca;
+  color: #7f8b88;
 }
 
 .previewPriceMeta {
@@ -515,5 +515,5 @@
   flex-wrap: wrap;
   gap: 12px;
   font-size: 13px;
-  color: #64748b;
+  color: #6f767c;
 }


### PR DESCRIPTION
## Summary
- rebalance the home page aurora background, navigation, hero, and cards with a lighter Morandi-inspired palette and frosted interactions
- align the zh-CN invoice form visuals with the refreshed theme by retuning backgrounds, inputs, buttons, and preview panels to muted glassy tones

## Testing
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ceb33551c483218d1b1abbdfa043df